### PR TITLE
Kill Edge before clearing cache

### DIFF
--- a/Clear-TempFiles.ps1
+++ b/Clear-TempFiles.ps1
@@ -135,6 +135,7 @@ Function Cleanup {
 
     # Clear Edge Chromium
     Write-Host -ForegroundColor Yellow "Clearing Edge Chromium Cache`n"
+    taskkill /F /IM msedge.exe
     Foreach ($user in $Users) {
         if (Test-Path "C:\Users\$user\AppData\Local\Microsoft\Edge\User Data") {
             Remove-Item -Path "C:\Users\$user\AppData\Local\Microsoft\Edge\User Data\Default\Cache\*" -Recurse -Force -ErrorAction SilentlyContinue -Verbose


### PR DESCRIPTION
Added taskkill /F /IM msedge.exe
If Edge isn't fully closed (it hangs around in taskmanager) then this script fails to successfully delete all of the cache